### PR TITLE
Loosen react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "homepage": "https://github.com/rrudol/useCookie#readme",
   "dependencies": {
     "js-cookie": "2.2.0",
-    "react": "16.8.0",
-    "react-dom": "16.8.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",


### PR DESCRIPTION
Otherwise you can't use this on 16.8.1, since you'll end up with two versions
of react and get a misleading "Hooks can only be called inside the body of a
function component" error